### PR TITLE
Create a shared function for importing c libraries.

### DIFF
--- a/rpyutils/__init__.py
+++ b/rpyutils/__init__.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from .add_dll_directories import add_dll_directories_from_env
+from .import_c_library import import_c_library
 
 
 __all__ = [
     'add_dll_directories_from_env',
+    'import_c_library',
 ]

--- a/rpyutils/import_c_library.py
+++ b/rpyutils/import_c_library.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Amazon.com Inc or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+from pathlib import Path
+
+from rpyutils import add_dll_directories_from_env
+
+
+def import_c_library(name, package):
+    try:
+        # Since Python 3.8, on Windows we should ensure DLL directories are
+        # explicitly added to the search path.
+        # See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+        with add_dll_directories_from_env('PATH'):
+            return importlib.import_module(name, package=package)
+    except ImportError as e:
+        if e.path is None:
+            import sysconfig
+            expected_path = Path(__file__).parents[1] / (
+                name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
+            assert not expected_path.is_file()
+            e.msg += \
+                f"\nThe C extension '{expected_path}' isn't present on the " \
+                "system. Please refer to 'https://index.ros.org/doc/ros2/" \
+                'Troubleshooting/Installation-Troubleshooting/#import-' \
+                "failing-without-library-present-on-the-system' for " \
+                'possible solutions'
+        if e.path is not None and os.path.isfile(e.path):
+            e.msg += \
+                f"\nThe C extension '{e.path}' failed to be imported while " \
+                "being present on the system. Please refer to 'https://" \
+                'index.ros.org/doc/ros2/Troubleshooting/Installation-' \
+                'Troubleshooting/#import-failing-even-with-library-present-' \
+                "on-the-system' for possible solutions"
+        raise

--- a/rpyutils/import_c_library.py
+++ b/rpyutils/import_c_library.py
@@ -15,11 +15,22 @@
 import importlib
 import os
 from pathlib import Path
+from typing import Optional
 
 from rpyutils import add_dll_directories_from_env
 
 
-def import_c_library(name, package):
+def import_c_library(name: str, package: Optional[str] = None):
+    """
+    Import and return a C extension library using importlib, with consistent error messaging.
+
+    See importlib.import_module documentation for details on the parameters and return type.
+
+    :param name
+    :param package
+    :return The loaded module
+    :raises ImportError
+    """
     try:
         # Since Python 3.8, on Windows we should ensure DLL directories are
         # explicitly added to the search path.


### PR DESCRIPTION
Create shared function for importing C libraries in Python with correct error handling and troubleshooting information.
Implementation copied from rclpy.impl._import, intended to replace that function and be usable elsewhere.

Not sure how to test this on its own - suggestions welcome.

Inspired by https://github.com/ros2/rosbag2/issues/445