### PR TITLE
Update troubleshooting links to docs.ros.org

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,8 @@
 
   <author email="jacob@openrobotics.org">Jacob Perron</author>
 
+  <exec_depend>ros_environment</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,6 @@
 
   <author email="jacob@openrobotics.org">Jacob Perron</author>
 
-  <exec_depend>ros_environment</exec_depend>
-
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/rpyutils/import_c_library.py
+++ b/rpyutils/import_c_library.py
@@ -38,17 +38,18 @@ def import_c_library(name: str, package: Optional[str] = None):
         with add_dll_directories_from_env('PATH'):
             return importlib.import_module(name, package=package)
     except ImportError as e:
+        distro = os.environ.get('ROS_DISTRO', 'rolling')
         if e.path is None:
             import sysconfig
             expected_path = Path(__file__).parents[1] / (
                 name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
             assert not expected_path.is_file()
-            link = f'https://docs.ros.org/en/rolling/Guides/Installation-Troubleshooting.html#import-failing-without-library-present-on-the-system'  # noqa: E501
+            link = f'https://docs.ros.org/en/{distro}/Guides/Installation-Troubleshooting.html#import-failing-without-library-present-on-the-system'  # noqa: E501
             e.msg += \
                 f"\nThe C extension '{expected_path}' isn't present on the " \
                 f"system. Please refer to '{link}' for possible solutions"
         if e.path is not None and os.path.isfile(e.path):
-            link = 'https://docs.ros.org/en/rolling/Guides/Installation-Troubleshooting.html#import-failing-even-with-library-present-on-the-system'  # noqa: E501
+            link = 'https://docs.ros.org/en/{distro}/Guides/Installation-Troubleshooting.html#import-failing-even-with-library-present-on-the-system'  # noqa: E501
             e.msg += \
                 f"\nThe C extension '{e.path}' failed to be imported while " \
                 f"being present on the system. Please refer to '{link}' for " \

--- a/rpyutils/import_c_library.py
+++ b/rpyutils/import_c_library.py
@@ -43,17 +43,14 @@ def import_c_library(name: str, package: Optional[str] = None):
             expected_path = Path(__file__).parents[1] / (
                 name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
             assert not expected_path.is_file()
+            link = f'https://docs.ros.org/en/rolling/Guides/Installation-Troubleshooting.html#import-failing-without-library-present-on-the-system'  # noqa: E501
             e.msg += \
                 f"\nThe C extension '{expected_path}' isn't present on the " \
-                "system. Please refer to 'https://index.ros.org/doc/ros2/" \
-                'Troubleshooting/Installation-Troubleshooting/#import-' \
-                "failing-without-library-present-on-the-system' for " \
-                'possible solutions'
+                f"system. Please refer to '{link}' for possible solutions"
         if e.path is not None and os.path.isfile(e.path):
+            link = 'https://docs.ros.org/en/rolling/Guides/Installation-Troubleshooting.html#import-failing-even-with-library-present-on-the-system'  # noqa: E501
             e.msg += \
                 f"\nThe C extension '{e.path}' failed to be imported while " \
-                "being present on the system. Please refer to 'https://" \
-                'index.ros.org/doc/ros2/Troubleshooting/Installation-' \
-                'Troubleshooting/#import-failing-even-with-library-present-' \
-                "on-the-system' for possible solutions"
+                f"being present on the system. Please refer to '{link}' for " \
+                'possible solutions'
         raise


### PR DESCRIPTION
This updates the two troubleshooting links to docs.ros.org. The redirection from index.ros.org to docs.ros.org didn't keep the `#tag`.

I also used `ros_environment` to be able to link to the right version of the docs, but if it's too overkill I can remove the second commit.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>